### PR TITLE
Update mdast versions to current versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "mdast": "~1.1.0",
-    "mdast-lint": "~1.1.0"
+    "mdast": "~2.2.0",
+    "mdast-lint": "~1.1.1"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
I haven't confirmed this by testing myself, but as I am apparently getting errors due to table support problems [since fixed](https://github.com/wooorm/mdast/commit/baad5362bb774cba5d56452f2736b6fab657179b), I'd appreciate a deployed version with these dependencies bumped... Thanks!
